### PR TITLE
fix(move-readme-with-sh): move the readme file in exec prepare step

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -28,7 +28,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepare": "node ./tools/edit-package.cjs ${nextRelease.version}"
+        "release": "node ./tools/prepare.sh ${nextRelease.version}"
       }
     ],
     [

--- a/tools/edit-package.cjs
+++ b/tools/edit-package.cjs
@@ -9,6 +9,4 @@ const pkgPath = path.resolve(__dirname, '../package/package.json');
 const readme = path.resolve(__dirname, '../README.md');
 
 fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
-fs.cp(readme, './package/README.md', (err) => {
-  if (err) console.error('error copying readme', err);
-});
+process.exit(0);

--- a/tools/prepare.sh
+++ b/tools/prepare.sh
@@ -1,0 +1,1 @@
+node ./tools/edit-package.cjs  "$1" && mv README.md ./package/README.md


### PR DESCRIPTION
leverage a exec file to edit version of package.json and move readme into package folder